### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://acejudoruiz.visualstudio.com/1e06d574-d8f7-4ef3-b0fa-4c5524b88bcb/096a1cce-4c8e-48db-88a5-a7a879fe9789/_apis/work/boardbadge/3d9bdb0c-cd81-49ff-b9f1-da38385b9e92)](https://acejudoruiz.visualstudio.com/1e06d574-d8f7-4ef3-b0fa-4c5524b88bcb/_boards/board/t/096a1cce-4c8e-48db-88a5-a7a879fe9789/Microsoft.RequirementCategory)
 # WebApiCore
 Test new version Asp.Net Core


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#45](https://acejudoruiz.visualstudio.com/1e06d574-d8f7-4ef3-b0fa-4c5524b88bcb/_workitems/edit/45). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.