### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/AdriRaziel/ee13d0fa-6dd7-4f06-93e0-49457548de4c/24834990-5b3d-43a8-b44c-50fea80f05c2/_apis/work/boardbadge/1085bd15-d044-4d4e-9a22-c6da6a3f0c7b)](https://dev.azure.com/AdriRaziel/ee13d0fa-6dd7-4f06-93e0-49457548de4c/_boards/board/t/24834990-5b3d-43a8-b44c-50fea80f05c2/Microsoft.RequirementCategory)
 # WebApiCore
 Test new version Asp.Net Core


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/AdriRaziel/ee13d0fa-6dd7-4f06-93e0-49457548de4c/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.